### PR TITLE
HA requires a "version" key in the manifest

### DIFF
--- a/custom_components/multisource/manifest.json
+++ b/custom_components/multisource/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "multisource",
   "name": "Multisource sensor",
+  "version": "1.0.0",
   "documentation": "https://github.com/akasma74/homeassistant-multisource-sensor",
   "requirements": [],
   "dependencies": [],


### PR DESCRIPTION
According to the [changelog for version 2021.3](https://www.home-assistant.io/blog/2021/03/03/release-20213/), the `version` key in the manifest.yml will be required in a future version of HA.